### PR TITLE
Fix args to to_csv call in self_close_xpath_search.py

### DIFF
--- a/self_close_xpath_search.py
+++ b/self_close_xpath_search.py
@@ -80,7 +80,7 @@ def save_results(output_dir, filename, results, datestamp=True):
     result_path = os.path.join(output_dir, filename)
 
     fieldnames = results[0].keys()
-    to_csv(fieldnames, results, result_path, datestamp)
+    to_csv(fieldnames, results, result_path, datestamp=datestamp)
 
 
 def add_additional_metadata(book_title,


### PR DESCRIPTION
When running self_close_xpath_search.py, I came across this error:

```
Saving csv file to /home/karen/src/ce-scripts/output/production-search-results_before_fix-20190725.csv
Traceback (most recent call last):
  File "self_close_xpath_search.py", line 182, in <module>
    save_results(output_dir, output_filename, results_data)
  File "self_close_xpath_search.py", line 83, in save_results
    to_csv(fieldnames, results, result_path, datestamp)
  File "/home/karen/src/ce-scripts/src/utils.py", line 21, in to_csv
    with open(filename, mode=mode) as outfile:
TypeError: open() argument 2 must be str, not bool
```

`src/utils.py` has been updated and the 4th argument is not `datestamp`
anymore, so it caused this error.