### PR TITLE
New script for making book repositories public

### DIFF
--- a/git-repo-prep/.env.example
+++ b/git-repo-prep/.env.example
@@ -1,0 +1,4 @@
+GIT_TERMINAL_PROMPT=0
+ABL_URL=https://raw.githubusercontent.com/openstax/content-manager-approved-books/main/approved-book-list.json
+GH_CLI_VERSION=2.9.0
+GITHUB_TOKEN=

--- a/git-repo-prep/.gitignore
+++ b/git-repo-prep/.gitignore
@@ -1,0 +1,10 @@
+**.DS_Store
+**node_modules
+**__pycache__
+.env
+books-list.json
+approved-book-list.json
+gh_*
+*.tar.gz
+tmp-gh-creds
+osbooks-*

--- a/git-repo-prep/.gitignore
+++ b/git-repo-prep/.gitignore
@@ -8,3 +8,4 @@ gh_*
 *.tar.gz
 tmp-gh-creds
 osbooks-*
+poet

--- a/git-repo-prep/README.md
+++ b/git-repo-prep/README.md
@@ -23,18 +23,20 @@ Make a copy of .env.example and rename it to .env.
 Generate a token for your GitHub account that has repository access.
 Paste your GitHub token in .env next to GITHUB_TOKEN=
 
-**NOTE** these functions will make changes to the live repositories online: make sure they are commented out in main.py if you do not wish to push changes. (They are commented out at the time of writing this)
-- cleanup_branches(git)
-- cleanup_tags(git)
-- git.push_changes()
+**NOTE** By default, the script will not make changes to the live repositories online. If you want to push changes add an argument the the script with a value of `p`, `push`, or `sync`.
+
+**NOTE** The script will set your git user to `Staxly` globally. You should reset it when you are done. This should really be done automatically, but it is not.
 
 Run it:
 ```bash
+# dry run
 python3 main.py
+# push changes
+python3 main.py push
 ```
 
 Dependencies:
-- npm
+- nodejs/npm
 - python3
 - wget
 - git

--- a/git-repo-prep/README.md
+++ b/git-repo-prep/README.md
@@ -1,0 +1,40 @@
+This script prepares book repositories for going public.
+
+Staxly is the mechanism that actually makes the repositories public based on the settings in .github/settings.yml.
+
+## What does this script do for each book in the ABL?
+
+1. Remove `*.vsix` files from repositories
+1. Remove `canonical.json` from repositories
+1. Generate `README.md` based on the templates in `git-repo-prep/static`
+1. Copy `git-repo-prep/static/repo-settings` into the repository
+1. Remove all branches that DO NOT conform to the regex `[0-9]+e` (1e, 2e, etc.)
+1. Remove all tags that DO conform to the regex `[0-9]+(rc){0,1}` (1, 1rc, etc.)
+1. Ensure that all collections use the same license
+1. Ensure that the correct license is used
+1. Push the above changes to Github (only when there are not any errors)
+
+## Is it idempotent?
+The entire process is based on git commits. Consequently, if there are not changes detected by git, no changes are committed.
+
+## How can I run it?
+
+Make a copy of .env.example and rename it to .env.
+Generate a token for your GitHub account that has repository access.
+Paste your GitHub token in .env next to GITHUB_TOKEN=
+
+**NOTE** these functions will make changes to the live repositories online: make sure they are commented out in main.py if you do not wish to push changes. (They are commented out at the time of writing this)
+- cleanup_branches(git)
+- cleanup_tags(git)
+- git.push_changes()
+
+Run it:
+```bash
+python3 main.py
+```
+
+Dependencies:
+- npm
+- python3
+- wget
+- git

--- a/git-repo-prep/README.md
+++ b/git-repo-prep/README.md
@@ -9,7 +9,7 @@ Staxly is the mechanism that actually makes the repositories public based on the
 1. Generate `README.md` based on the templates in `git-repo-prep/static`
 1. Copy `git-repo-prep/static/repo-settings` into the repository
 1. Remove all branches that DO NOT conform to the regex `[0-9]+e` (1e, 2e, etc.)
-1. Remove all tags that DO conform to the regex `[0-9]+(rc){0,1}` (1, 1rc, etc.)
+1. Remove all tags
 1. Ensure that all collections use the same license
 1. Ensure that the correct license is used
 1. Push the above changes to Github (only when there are not any errors)

--- a/git-repo-prep/index.ts
+++ b/git-repo-prep/index.ts
@@ -140,7 +140,7 @@ function createBookReadme(templateDir: string, slugMeta: SlugMeta) {
   const templatePath = path.join(templateDir, 'book.md')
   const replacements = {
     'book_title': slugMeta.colMeta.title,
-    'book_slug': slugMeta.slugName,
+    'book_link': `${BOOK_WEB_ROOT}${encodeURIComponent(slugMeta.slugName)}`,
     'license_text': slugMeta.colMeta.license.text,
     'license_type': slugMeta.colMeta.license.type,
     'license_version': slugMeta.colMeta.license.version
@@ -154,10 +154,10 @@ function createBundleReadme(templateDir: string, slugsMeta: SlugMeta[]) {
     'book_titles':
       slugsMeta.map((s, i) =>
         i === slugsMeta.length - 1 ? `and ${s.colMeta.title}` : s.colMeta.title
-      ).join(', '),
+      ).join(slugsMeta.length > 2 ? ', ' : ' '),
     'book_links':
       slugsMeta.map(s =>
-        `- _${s.colMeta.title}_ [online](${BOOK_WEB_ROOT}${s.slugName})`
+        `- _${s.colMeta.title}_ [online](${BOOK_WEB_ROOT}${encodeURIComponent(s.slugName)})`
       ).join('\n'),
     'license_text': slugsMeta[0].colMeta.license.text,
     'license_type': slugsMeta[0].colMeta.license.type,
@@ -168,13 +168,14 @@ function createBundleReadme(templateDir: string, slugsMeta: SlugMeta[]) {
 
 function populateTemplate(templatePath: string, replacements: Record<string, string>) {
   let template = fs.readFileSync(templatePath, { encoding: 'utf-8' })
-  // '{{ test }}' -> '{ test }'
-  // '{ x }' -> replacements['x']
-  return template.replace(new RegExp('\{{1,2}.+?\}{1,2}', 'g'), m => {
-    const prop = m.slice(1, -1)
-    return prop.startsWith('{') && prop.endsWith('}')
-      ? prop
-      : replacements[prop.trim()]
+  // '{{ x }}' -> replacements['x']
+  return template.replace(new RegExp('\{{2}.+?\}{2}', 'g'), m => {
+    const prop = m.slice(2, -2)
+    const value = replacements[prop.trim()]
+    if (value === undefined) {
+      throw new Error(`${prop} is undefined`)
+    }
+    return value
   })
 }
 

--- a/git-repo-prep/index.ts
+++ b/git-repo-prep/index.ts
@@ -148,8 +148,19 @@ function createBookReadme(templateDir: string, slugMeta: SlugMeta) {
   return populateTemplate(templatePath, replacements)
 }
 
+function licenseEqual(a: License, b: License) {
+  return a.type === b.type &&
+    a.text === b.text &&
+    a.url === b.url &&
+    a.version === b.version
+}
+
 function createBundleReadme(templateDir: string, slugsMeta: SlugMeta[]) {
   const templatePath = path.join(templateDir, 'bundle.md')
+  const license = slugsMeta[0].colMeta.license
+  if (!slugsMeta.every(sm => licenseEqual(sm.colMeta.license, license))) {
+    throw new Error('Licenses differ between collections')
+  }
   const replacements = {
     'book_titles':
       slugsMeta.map((s, i) =>
@@ -159,9 +170,9 @@ function createBundleReadme(templateDir: string, slugsMeta: SlugMeta[]) {
       slugsMeta.map(s =>
         `- _${s.colMeta.title}_ [online](${BOOK_WEB_ROOT}${encodeURIComponent(s.slugName)})`
       ).join('\n'),
-    'license_text': slugsMeta[0].colMeta.license.text,
-    'license_type': slugsMeta[0].colMeta.license.type,
-    'license_version': slugsMeta[0].colMeta.license.version
+    'license_text': license.text,
+    'license_type': license.type,
+    'license_version': license.version
   }
   return populateTemplate(templatePath, replacements)
 }

--- a/git-repo-prep/index.ts
+++ b/git-repo-prep/index.ts
@@ -1,0 +1,213 @@
+import fs from 'fs'
+import path from 'path'
+
+import { DOMParser } from 'xmldom'
+import * as xpath from 'xpath-ts'
+
+const NS_COLLECTION = 'http://cnx.rice.edu/collxml'
+const NS_CNXML = 'http://cnx.rice.edu/cnxml'
+const NS_METADATA = 'http://cnx.rice.edu/mdml'
+const NS_CONTAINER = 'https://openstax.org/namespaces/book-container'
+
+export function expectValue<T>(value: T | null | undefined, message: string): T {
+  if (value == null) {
+    throw new Error(message)
+  }
+  return value
+}
+
+const select = xpath.useNamespaces({ cnxml: NS_CNXML, col: NS_COLLECTION, md: NS_METADATA, bk: NS_CONTAINER })
+const selectOne = (sel: string, doc: Node): Element => {
+  const ret = select(sel, doc) as Node[]
+  expectValue(ret.length === 1 || null, `ERROR: Expected one but found ${ret.length} results that match '${sel}'`)
+  return ret[0] as Element
+}
+
+
+const BOOK_WEB_ROOT = 'https://openstax.org/details/books/'
+const LICENSE_TEXT_MAP: Record<string, string> = {
+  'by':
+    'Creative Commons Attribution License',
+  'by-nd':
+    'Creative Commons Attribution-NoDerivs License',
+  'by-nd-nc':
+    'Creative Commons Attribution-NoDerivs-NonCommercial License',
+  'by-sa':
+    'Creative Commons Attribution-ShareAlike License',
+  'by-nc':
+    'Creative Commons Attribution-NonCommercial License',
+  'by-nc-sa':
+    'Creative Commons Attribution-NonCommercial-ShareAlike License',
+}
+
+interface License {
+  url: string,
+  type: string,
+  version: string,
+  text: string
+}
+
+interface ColMeta {
+  title: string,
+  license: License
+}
+
+interface SlugMeta {
+  slugName: string,
+  collectionId: string,
+  href: string,
+  colMeta: ColMeta
+}
+
+interface BookMeta {
+  slugsMeta: SlugMeta[]
+}
+
+function getLicense(license: Element): License {
+  let url = expectValue(license.getAttribute('url'), 'No license url')
+  let text: string | undefined
+  const isLocalized = url.includes('/deed.')
+  if (url.endsWith('/')) {
+    url = url.slice(0, url.length - 1)
+  }
+  const [type, version] = (
+    isLocalized ? url.slice(0, url.lastIndexOf('/deed.')) : url
+  ).split('/').slice(-2)
+  text = isLocalized || !(type in LICENSE_TEXT_MAP)
+    ? license.textContent?.trim()
+    : LICENSE_TEXT_MAP[type]
+  if (text === undefined || text.length === 0) {
+    throw new Error('Expected license text')
+  }
+  
+  return { url, type, version, text }
+}
+
+function getCollectionMeta(colPath: string): ColMeta {
+  const metaXpath = '//*[local-name() = "metadata"]'
+  const titleXpath = `${metaXpath}/md:title`
+  const licenseXpath = `${metaXpath}/md:license`
+
+  const collection = fs.readFileSync(colPath, { encoding: 'utf-8' })
+  const doc = new DOMParser().parseFromString(collection)
+  const title = expectValue(selectOne(titleXpath, doc).textContent, 'No title')
+  const licenseEl = selectOne(licenseXpath, doc)
+
+  return {
+    title: title,
+    license: getLicense(licenseEl)
+  }
+}
+
+function getBookMeta(bookPath: string): BookMeta {
+  const booksXmlPath = getBooksXmlPath(bookPath)
+  const booksXml = fs.readFileSync(booksXmlPath, { encoding: 'utf-8' })
+  const doc = new DOMParser().parseFromString(booksXml)
+  const slugsMeta: SlugMeta[] = []
+  const slugs = select('//*[@slug]', doc) as Element[]
+  for (const slug of slugs) {
+    const slugName = expectValue(slug.getAttribute('slug'), 'Slug not found')
+    const href = expectValue(slug.getAttribute('href'), 'Slug href not found')
+    const collectionId = expectValue(
+      slug.getAttribute('collection-id'),
+      'collection-id not found'
+    )
+    const colPath = getColPath(booksXmlPath, href)
+    const colMeta = getCollectionMeta(colPath)
+    slugsMeta.push({ slugName, collectionId, href, colMeta })
+  }
+  return { slugsMeta }
+}
+
+function getBooksXmlPath(bookPath: string) {
+  return path.join(bookPath, 'META-INF', 'books.xml')
+}
+
+function getColPath(booksXmlPath: string, href: string): string {
+  return path.join(path.dirname(booksXmlPath), href)
+}
+
+function writeReadme(meta: BookMeta, bookPath: string, templateDir: string) {
+  fs.writeFileSync(
+    path.join(bookPath, 'README.md'),
+    meta.slugsMeta.length === 1
+      ? createBookReadme(templateDir, meta.slugsMeta[0])
+      : createBundleReadme(templateDir, meta.slugsMeta)
+  )
+}
+
+function createBookReadme(templateDir: string, slugMeta: SlugMeta) {
+  const templatePath = path.join(templateDir, 'book.md')
+  const replacements = {
+    'book_title': slugMeta.colMeta.title,
+    'book_slug': slugMeta.slugName,
+    'license_text': slugMeta.colMeta.license.text,
+    'license_type': slugMeta.colMeta.license.type,
+    'license_version': slugMeta.colMeta.license.version
+  }
+  return populateTemplate(templatePath, replacements)
+}
+
+function createBundleReadme(templateDir: string, slugsMeta: SlugMeta[]) {
+  const templatePath = path.join(templateDir, 'bundle.md')
+  const replacements = {
+    'book_titles':
+      slugsMeta.map((s, i) =>
+        i === slugsMeta.length - 1 ? `and ${s.colMeta.title}` : s.colMeta.title
+      ).join(', '),
+    'book_links':
+      slugsMeta.map(s =>
+        `- _${s.colMeta.title}_ [online](${BOOK_WEB_ROOT}${s.slugName})`
+      ).join('\n'),
+    'license_text': slugsMeta[0].colMeta.license.text,
+    'license_type': slugsMeta[0].colMeta.license.type,
+    'license_version': slugsMeta[0].colMeta.license.version
+  }
+  return populateTemplate(templatePath, replacements)
+}
+
+function populateTemplate(templatePath: string, replacements: Record<string, string>) {
+  let template = fs.readFileSync(templatePath, { encoding: 'utf-8' })
+  // '{{ test }}' -> '{ test }'
+  // '{ x }' -> replacements['x']
+  return template.replace(new RegExp('\{{1,2}.+?\}{1,2}', 'g'), m => {
+    const prop = m.slice(1, -1)
+    return prop.startsWith('{') && prop.endsWith('}')
+      ? prop
+      : replacements[prop.trim()]
+  })
+}
+
+function copyRepoSettings(bookPath: string, settingsDir: string) {
+  function recCopyDir(src: string, dst: string) {
+    if (!fs.existsSync(dst)) {
+      fs.mkdirSync(dst)
+    }
+    for (const dirent of fs.readdirSync(src, { withFileTypes: true })) {
+      if (dirent.isDirectory()) {
+        recCopyDir(
+          path.join(src, dirent.name),
+          path.join(dst, dirent.name)
+        )
+      } else if (dirent.isFile()) {
+        fs.copyFileSync(
+          path.join(src, dirent.name),
+          path.join(dst, dirent.name)
+        )
+      }
+    }
+  }
+  recCopyDir(settingsDir, bookPath)
+}
+
+function prepareBookRepo(bookPath: string, staticResourceDir: string) {
+  const meta = getBookMeta(bookPath)
+  writeReadme(meta, bookPath, staticResourceDir)
+  copyRepoSettings(bookPath, path.join(staticResourceDir, 'repo-settings'))
+  
+  // This is a temporary addition so that the python script can handle the
+  // license related work that is out of the scope of this script
+  console.log(JSON.stringify(meta))
+}
+
+prepareBookRepo(process.argv[2], path.join(__dirname, 'static'))

--- a/git-repo-prep/licenses/by-4.0.txt
+++ b/git-repo-prep/licenses/by-4.0.txt
@@ -1,0 +1,397 @@
+Attribution 4.0 International
+
+=======================================================================
+
+Creative Commons Corporation ("Creative Commons") is not a law firm and
+does not provide legal services or legal advice. Distribution of
+Creative Commons public licenses does not create a lawyer-client or
+other relationship. Creative Commons makes its licenses and related
+information available on an "as-is" basis. Creative Commons gives no
+warranties regarding its licenses, any material licensed under their
+terms and conditions, or any related information. Creative Commons
+disclaims all liability for damages resulting from their use to the
+fullest extent possible.
+
+Using Creative Commons Public Licenses
+
+Creative Commons public licenses provide a standard set of terms and
+conditions that creators and other rights holders may use to share
+original works of authorship and other material subject to copyright
+and certain other rights specified in the public license below. The
+following considerations are for informational purposes only, are not
+exhaustive, and do not form part of our licenses.
+
+     Considerations for licensors: Our public licenses are
+     intended for use by those authorized to give the public
+     permission to use material in ways otherwise restricted by
+     copyright and certain other rights. Our licenses are
+     irrevocable. Licensors should read and understand the terms
+     and conditions of the license they choose before applying it.
+     Licensors should also secure all rights necessary before
+     applying our licenses so that the public can reuse the
+     material as expected. Licensors should clearly mark any
+     material not subject to the license. This includes other CC-
+     licensed material, or material used under an exception or
+     limitation to copyright. More considerations for licensors:
+     wiki.creativecommons.org/Considerations_for_licensors
+
+     Considerations for the public: By using one of our public
+     licenses, a licensor grants the public permission to use the
+     licensed material under specified terms and conditions. If
+     the licensor's permission is not necessary for any reason--for
+     example, because of any applicable exception or limitation to
+     copyright--then that use is not regulated by the license. Our
+     licenses grant only permissions under copyright and certain
+     other rights that a licensor has authority to grant. Use of
+     the licensed material may still be restricted for other
+     reasons, including because others have copyright or other
+     rights in the material. A licensor may make special requests,
+     such as asking that all changes be marked or described.
+     Although not required by our licenses, you are encouraged to
+     respect those requests where reasonable. More considerations
+     for the public:
+     wiki.creativecommons.org/Considerations_for_licensees
+
+=======================================================================
+
+Creative Commons Attribution 4.0 International Public License
+
+By exercising the Licensed Rights (defined below), You accept and agree
+to be bound by the terms and conditions of this Creative Commons
+Attribution 4.0 International Public License ("Public License"). To the
+extent this Public License may be interpreted as a contract, You are
+granted the Licensed Rights in consideration of Your acceptance of
+these terms and conditions, and the Licensor grants You such rights in
+consideration of benefits the Licensor receives from making the
+Licensed Material available under these terms and conditions.
+
+
+Section 1 -- Definitions.
+
+  a. Adapted Material means material subject to Copyright and Similar
+     Rights that is derived from or based upon the Licensed Material
+     and in which the Licensed Material is translated, altered,
+     arranged, transformed, or otherwise modified in a manner requiring
+     permission under the Copyright and Similar Rights held by the
+     Licensor. For purposes of this Public License, where the Licensed
+     Material is a musical work, performance, or sound recording,
+     Adapted Material is always produced where the Licensed Material is
+     synched in timed relation with a moving image.
+
+  b. Adapter's License means the license You apply to Your Copyright
+     and Similar Rights in Your contributions to Adapted Material in
+     accordance with the terms and conditions of this Public License.
+
+  c. Copyright and Similar Rights means copyright and/or similar rights
+     closely related to copyright including, without limitation,
+     performance, broadcast, sound recording, and Sui Generis Database
+     Rights, without regard to how the rights are labeled or
+     categorized. For purposes of this Public License, the rights
+     specified in Section 2(b)(1)-(2) are not Copyright and Similar
+     Rights.
+
+  d. Effective Technological Measures means those measures that, in the
+     absence of proper authority, may not be circumvented under laws
+     fulfilling obligations under Article 11 of the WIPO Copyright
+     Treaty adopted on December 20, 1996, and/or similar international
+     agreements.
+
+  e. Exceptions and Limitations means fair use, fair dealing, and/or
+     any other exception or limitation to Copyright and Similar Rights
+     that applies to Your use of the Licensed Material.
+
+  f. Licensed Material means the artistic or literary work, database,
+     or other material to which the Licensor applied this Public
+     License.
+
+  g. Licensed Rights means the rights granted to You subject to the
+     terms and conditions of this Public License, which are limited to
+     all Copyright and Similar Rights that apply to Your use of the
+     Licensed Material and that the Licensor has authority to license.
+
+  h. Licensor means the individual(s) or entity(ies) granting rights
+     under this Public License.
+
+  i. Share means to provide material to the public by any means or
+     process that requires permission under the Licensed Rights, such
+     as reproduction, public display, public performance, distribution,
+     dissemination, communication, or importation, and to make material
+     available to the public including in ways that members of the
+     public may access the material from a place and at a time
+     individually chosen by them.
+
+  j. Sui Generis Database Rights means rights other than copyright
+     resulting from Directive 96/9/EC of the European Parliament and of
+     the Council of 11 March 1996 on the legal protection of databases,
+     as amended and/or succeeded, as well as other essentially
+     equivalent rights anywhere in the world.
+
+  k. You means the individual or entity exercising the Licensed Rights
+     under this Public License. Your has a corresponding meaning.
+
+
+Section 2 -- Scope.
+
+  a. License grant.
+
+       1. Subject to the terms and conditions of this Public License,
+          the Licensor hereby grants You a worldwide, royalty-free,
+          non-sublicensable, non-exclusive, irrevocable license to
+          exercise the Licensed Rights in the Licensed Material to:
+
+            a. reproduce and Share the Licensed Material, in whole or
+               in part; and
+
+            b. produce, reproduce, and Share Adapted Material.
+
+       2. Exceptions and Limitations. For the avoidance of doubt, where
+          Exceptions and Limitations apply to Your use, this Public
+          License does not apply, and You do not need to comply with
+          its terms and conditions.
+
+       3. Term. The term of this Public License is specified in Section
+          6(a).
+
+       4. Media and formats; technical modifications allowed. The
+          Licensor authorizes You to exercise the Licensed Rights in
+          all media and formats whether now known or hereafter created,
+          and to make technical modifications necessary to do so. The
+          Licensor waives and/or agrees not to assert any right or
+          authority to forbid You from making technical modifications
+          necessary to exercise the Licensed Rights, including
+          technical modifications necessary to circumvent Effective
+          Technological Measures. For purposes of this Public License,
+          simply making modifications authorized by this Section 2(a)
+          (4) never produces Adapted Material.
+
+       5. Downstream recipients.
+
+            a. Offer from the Licensor -- Licensed Material. Every
+               recipient of the Licensed Material automatically
+               receives an offer from the Licensor to exercise the
+               Licensed Rights under the terms and conditions of this
+               Public License.
+
+            b. No downstream restrictions. You may not offer or impose
+               any additional or different terms or conditions on, or
+               apply any Effective Technological Measures to, the
+               Licensed Material if doing so restricts exercise of the
+               Licensed Rights by any recipient of the Licensed
+               Material.
+
+       6. No endorsement. Nothing in this Public License constitutes or
+          may be construed as permission to assert or imply that You
+          are, or that Your use of the Licensed Material is, connected
+          with, or sponsored, endorsed, or granted official status by,
+          the Licensor or others designated to receive attribution as
+          provided in Section 3(a)(1)(A)(i).
+
+  b. Other rights.
+
+       1. Moral rights, such as the right of integrity, are not
+          licensed under this Public License, nor are publicity,
+          privacy, and/or other similar personality rights; however, to
+          the extent possible, the Licensor waives and/or agrees not to
+          assert any such rights held by the Licensor to the limited
+          extent necessary to allow You to exercise the Licensed
+          Rights, but not otherwise.
+
+       2. Patent and trademark rights are not licensed under this
+          Public License.
+
+       3. To the extent possible, the Licensor waives any right to
+          collect royalties from You for the exercise of the Licensed
+          Rights, whether directly or through a collecting society
+          under any voluntary or waivable statutory or compulsory
+          licensing scheme. In all other cases the Licensor expressly
+          reserves any right to collect such royalties.
+
+
+Section 3 -- License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the
+following conditions.
+
+  a. Attribution.
+
+       1. If You Share the Licensed Material (including in modified
+          form), You must:
+
+            a. retain the following if it is supplied by the Licensor
+               with the Licensed Material:
+
+                 i. identification of the creator(s) of the Licensed
+                    Material and any others designated to receive
+                    attribution, in any reasonable manner requested by
+                    the Licensor (including by pseudonym if
+                    designated);
+
+                ii. a copyright notice;
+
+               iii. a notice that refers to this Public License;
+
+                iv. a notice that refers to the disclaimer of
+                    warranties;
+
+                 v. a URI or hyperlink to the Licensed Material to the
+                    extent reasonably practicable;
+
+            b. indicate if You modified the Licensed Material and
+               retain an indication of any previous modifications; and
+
+            c. indicate the Licensed Material is licensed under this
+               Public License, and include the text of, or the URI or
+               hyperlink to, this Public License.
+
+       2. You may satisfy the conditions in Section 3(a)(1) in any
+          reasonable manner based on the medium, means, and context in
+          which You Share the Licensed Material. For example, it may be
+          reasonable to satisfy the conditions by providing a URI or
+          hyperlink to a resource that includes the required
+          information.
+
+       3. If requested by the Licensor, You must remove any of the
+          information required by Section 3(a)(1)(A) to the extent
+          reasonably practicable.
+
+       4. If You Share Adapted Material You produce, the Adapter's
+          License You apply must not prevent recipients of the Adapted
+          Material from complying with this Public License.
+
+
+Section 4 -- Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that
+apply to Your use of the Licensed Material:
+
+  a. for the avoidance of doubt, Section 2(a)(1) grants You the right
+     to extract, reuse, reproduce, and Share all or a substantial
+     portion of the contents of the database;
+
+  b. if You include all or a substantial portion of the database
+     contents in a database in which You have Sui Generis Database
+     Rights, then the database in which You have Sui Generis Database
+     Rights (but not its individual contents) is Adapted Material; and
+
+  c. You must comply with the conditions in Section 3(a) if You Share
+     all or a substantial portion of the contents of the database.
+
+For the avoidance of doubt, this Section 4 supplements and does not
+replace Your obligations under this Public License where the Licensed
+Rights include other Copyright and Similar Rights.
+
+
+Section 5 -- Disclaimer of Warranties and Limitation of Liability.
+
+  a. UNLESS OTHERWISE SEPARATELY UNDERTAKEN BY THE LICENSOR, TO THE
+     EXTENT POSSIBLE, THE LICENSOR OFFERS THE LICENSED MATERIAL AS-IS
+     AND AS-AVAILABLE, AND MAKES NO REPRESENTATIONS OR WARRANTIES OF
+     ANY KIND CONCERNING THE LICENSED MATERIAL, WHETHER EXPRESS,
+     IMPLIED, STATUTORY, OR OTHER. THIS INCLUDES, WITHOUT LIMITATION,
+     WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR
+     PURPOSE, NON-INFRINGEMENT, ABSENCE OF LATENT OR OTHER DEFECTS,
+     ACCURACY, OR THE PRESENCE OR ABSENCE OF ERRORS, WHETHER OR NOT
+     KNOWN OR DISCOVERABLE. WHERE DISCLAIMERS OF WARRANTIES ARE NOT
+     ALLOWED IN FULL OR IN PART, THIS DISCLAIMER MAY NOT APPLY TO YOU.
+
+  b. TO THE EXTENT POSSIBLE, IN NO EVENT WILL THE LICENSOR BE LIABLE
+     TO YOU ON ANY LEGAL THEORY (INCLUDING, WITHOUT LIMITATION,
+     NEGLIGENCE) OR OTHERWISE FOR ANY DIRECT, SPECIAL, INDIRECT,
+     INCIDENTAL, CONSEQUENTIAL, PUNITIVE, EXEMPLARY, OR OTHER LOSSES,
+     COSTS, EXPENSES, OR DAMAGES ARISING OUT OF THIS PUBLIC LICENSE OR
+     USE OF THE LICENSED MATERIAL, EVEN IF THE LICENSOR HAS BEEN
+     ADVISED OF THE POSSIBILITY OF SUCH LOSSES, COSTS, EXPENSES, OR
+     DAMAGES. WHERE A LIMITATION OF LIABILITY IS NOT ALLOWED IN FULL OR
+     IN PART, THIS LIMITATION MAY NOT APPLY TO YOU.
+
+  c. The disclaimer of warranties and limitation of liability provided
+     above shall be interpreted in a manner that, to the extent
+     possible, most closely approximates an absolute disclaimer and
+     waiver of all liability.
+
+
+Section 6 -- Term and Termination.
+
+  a. This Public License applies for the term of the Copyright and
+     Similar Rights licensed here. However, if You fail to comply with
+     this Public License, then Your rights under this Public License
+     terminate automatically.
+
+  b. Where Your right to use the Licensed Material has terminated under
+     Section 6(a), it reinstates:
+
+       1. automatically as of the date the violation is cured, provided
+          it is cured within 30 days of Your discovery of the
+          violation; or
+
+       2. upon express reinstatement by the Licensor.
+
+     For the avoidance of doubt, this Section 6(b) does not affect any
+     right the Licensor may have to seek remedies for Your violations
+     of this Public License.
+
+  c. For the avoidance of doubt, the Licensor may also offer the
+     Licensed Material under separate terms or conditions or stop
+     distributing the Licensed Material at any time; however, doing so
+     will not terminate this Public License.
+
+  d. Sections 1, 5, 6, 7, and 8 survive termination of this Public
+     License.
+
+
+Section 7 -- Other Terms and Conditions.
+
+  a. The Licensor shall not be bound by any additional or different
+     terms or conditions communicated by You unless expressly agreed.
+
+  b. Any arrangements, understandings, or agreements regarding the
+     Licensed Material not stated herein are separate from and
+     independent of the terms and conditions of this Public License.
+
+
+Section 8 -- Interpretation.
+
+  a. For the avoidance of doubt, this Public License does not, and
+     shall not be interpreted to, reduce, limit, restrict, or impose
+     conditions on any use of the Licensed Material that could lawfully
+     be made without permission under this Public License.
+
+  b. To the extent possible, if any provision of this Public License is
+     deemed unenforceable, it shall be automatically reformed to the
+     minimum extent necessary to make it enforceable. If the provision
+     cannot be reformed, it shall be severed from this Public License
+     without affecting the enforceability of the remaining terms and
+     conditions.
+
+  c. No term or condition of this Public License will be waived and no
+     failure to comply consented to unless expressly agreed to by the
+     Licensor.
+
+  d. Nothing in this Public License constitutes or may be interpreted
+     as a limitation upon, or waiver of, any privileges and immunities
+     that apply to the Licensor or You, including from the legal
+     processes of any jurisdiction or authority.
+
+
+=======================================================================
+
+Creative Commons is not a party to its public licenses.
+Notwithstanding, Creative Commons may elect to apply one of its public
+licenses to material it publishes and in those instances will be
+considered the “Licensor.” The text of the Creative Commons public
+licenses is dedicated to the public domain under the CC0 Public Domain
+Dedication. Except for the limited purpose of indicating that material
+is shared under a Creative Commons public license or as otherwise
+permitted by the Creative Commons policies published at
+creativecommons.org/policies, Creative Commons does not authorize the
+use of the trademark "Creative Commons" or any other trademark or logo
+of Creative Commons without its prior written consent including,
+without limitation, in connection with any unauthorized modifications
+to any of its public licenses or any other arrangements,
+understandings, or agreements concerning use of licensed material. For
+the avoidance of doubt, this paragraph does not form part of the public
+licenses.
+
+Creative Commons may be contacted at creativecommons.org.
+
+https://choosealicense.com/licenses/cc-by-4.0/#

--- a/git-repo-prep/licenses/by-nc-sa-4.0.txt
+++ b/git-repo-prep/licenses/by-nc-sa-4.0.txt
@@ -1,0 +1,430 @@
+Attribution-NonCommercial-ShareAlike 4.0 International
+
+=======================================================================
+
+Creative Commons Corporation ("Creative Commons") is not a law firm and
+does not provide legal services or legal advice. Distribution of
+Creative Commons public licenses does not create a lawyer-client or
+other relationship. Creative Commons makes its licenses and related
+information available on an "as-is" basis. Creative Commons gives no
+warranties regarding its licenses, any material licensed under their
+terms and conditions, or any related information. Creative Commons
+disclaims all liability for damages resulting from their use to the
+fullest extent possible.
+
+Using Creative Commons Public Licenses
+
+Creative Commons public licenses provide a standard set of terms and
+conditions that creators and other rights holders may use to share
+original works of authorship and other material subject to copyright
+and certain other rights specified in the public license below. The
+following considerations are for informational purposes only, are not
+exhaustive, and do not form part of our licenses.
+
+     Considerations for licensors: Our public licenses are
+     intended for use by those authorized to give the public
+     permission to use material in ways otherwise restricted by
+     copyright and certain other rights. Our licenses are
+     irrevocable. Licensors should read and understand the terms
+     and conditions of the license they choose before applying it.
+     Licensors should also secure all rights necessary before
+     applying our licenses so that the public can reuse the
+     material as expected. Licensors should clearly mark any
+     material not subject to the license. This includes other CC-
+     licensed material, or material used under an exception or
+     limitation to copyright. More considerations for licensors:
+     wiki.creativecommons.org/Considerations_for_licensors
+
+     Considerations for the public: By using one of our public
+     licenses, a licensor grants the public permission to use the
+     licensed material under specified terms and conditions. If
+     the licensor's permission is not necessary for any reason--for
+     example, because of any applicable exception or limitation to
+     copyright--then that use is not regulated by the license. Our
+     licenses grant only permissions under copyright and certain
+     other rights that a licensor has authority to grant. Use of
+     the licensed material may still be restricted for other
+     reasons, including because others have copyright or other
+     rights in the material. A licensor may make special requests,
+     such as asking that all changes be marked or described.
+     Although not required by our licenses, you are encouraged to
+     respect those requests where reasonable. More considerations
+     for the public:
+     wiki.creativecommons.org/Considerations_for_licensees
+
+=======================================================================
+
+Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International
+Public License
+
+By exercising the Licensed Rights (defined below), You accept and agree to be bound by the terms
+and conditions of this Creative Commons Attribution-NonCommercial-ShareAlike
+4.0 International Public License ("Public License"). To the extent this Public
+License may be interpreted as a contract, You are granted the Licensed Rights
+in consideration of Your acceptance of these terms and conditions, and the
+Licensor grants You such rights in consideration of benefits the Licensor
+receives from making the Licensed Material available under these terms and
+conditions.
+
+Section 1 – Definitions.
+
+    a. Adapted Material means material subject to Copyright and Similar
+        Rights that is derived from or based upon the Licensed Material
+        and in which the Licensed Material is translated, altered,
+        arranged, transformed, or otherwise modified in a manner requiring
+        permission under the Copyright and Similar Rights held by the
+        Licensor. For purposes of this Public License, where the Licensed
+        Material is a musical work, performance, or sound recording,
+        Adapted Material is always produced where the Licensed Material is
+        synched in timed relation with a moving image.
+
+    b. Adapter's License means the license You apply to Your Copyright
+        and Similar Rights in Your contributions to Adapted Material in
+        accordance with the terms and conditions of this Public License.
+
+    c.  BY-NC-SA Compatible License means a license listed at
+        creativecommons.org/compatiblelicenses, approved by Creative
+        Commons as essentially the equivalent of this Public License.
+
+    d.  Copyright and Similar Rights means copyright and/or similar rights
+        closely related to copyright including, without limitation,
+        performance, broadcast, sound recording, and Sui Generis Database
+        Rights, without regard to how the rights are labeled or
+        categorized. For purposes of this Public License, the rights
+        specified in Section 2(b)(1)-(2) are not Copyright and Similar
+        Rights.
+
+    e. Effective Technological Measures means those measures that, in the
+        absence of proper authority, may not be circumvented under laws
+        fulfilling obligations under Article 11 of the WIPO Copyright
+        Treaty adopted on December 20, 1996, and/or similar international
+        agreements.
+
+    f. Exceptions and Limitations means fair use, fair dealing, and/or
+        any other exception or limitation to Copyright and Similar Rights
+        that applies to Your use of the Licensed Material.
+
+    g. License Elements means the license attributes listed in the name
+        of a Creative Commons Public License. The License Elements of this
+        Public License are Attribution and ShareAlike.
+
+    h. Licensed Material means the artistic or literary work, database,
+        or other material to which the Licensor applied this Public
+        License.
+
+    i. Licensed Rights means the rights granted to You subject to the
+        terms and conditions of this Public License, which are limited to
+        all Copyright and Similar Rights that apply to Your use of the
+        Licensed Material and that the Licensor has authority to license.
+
+    j. Licensor means the individual(s) or entity(ies) granting rights
+        under this Public License.
+
+    k.  NonCommercial means not primarily intended for or directed towards
+        commercial advantage or monetary compensation. For purposes of this
+        Public License, the exchange of the Licensed Material for other
+        material subject to Copyright and Similar Rights by digital file-sharing
+        or similar means is NonCommercial provided there is no payment of
+        monetary compensation in connection with the exchange.
+
+    l. Share means to provide material to the public by any means or
+        process that requires permission under the Licensed Rights, such
+        as reproduction, public display, public performance, distribution,
+        dissemination, communication, or importation, and to make material
+        available to the public including in ways that members of the
+        public may access the material from a place and at a time
+        individually chosen by them.
+
+    m. Sui Generis Database Rights means rights other than copyright
+        resulting from Directive 96/9/EC of the European Parliament and of
+        the Council of 11 March 1996 on the legal protection of databases,
+        as amended and/or succeeded, as well as other essentially
+        equivalent rights anywhere in the world.
+
+    n. You means the individual or entity exercising the Licensed Rights
+        under this Public License. Your has a corresponding meaning.
+
+Section 2 -- Scope.
+
+  a. License grant.
+
+       1. Subject to the terms and conditions of this Public License,
+          the Licensor hereby grants You a worldwide, royalty-free,
+          non-sublicensable, non-exclusive, irrevocable license to
+          exercise the Licensed Rights in the Licensed Material to:
+
+            a. 	reproduce and Share the Licensed Material, in whole or
+                in part, for NonCommercial purposes only; and
+
+            b. produce, reproduce, and Share Adapted Material for
+                NonCommercial purposes only.
+
+       2. Exceptions and Limitations. For the avoidance of doubt, where
+          Exceptions and Limitations apply to Your use, this Public
+          License does not apply, and You do not need to comply with
+          its terms and conditions.
+
+       3. Term. The term of this Public License is specified in Section
+          6(a).
+
+       4. Media and formats; technical modifications allowed. The
+          Licensor authorizes You to exercise the Licensed Rights in
+          all media and formats whether now known or hereafter created,
+          and to make technical modifications necessary to do so. The
+          Licensor waives and/or agrees not to assert any right or
+          authority to forbid You from making technical modifications
+          necessary to exercise the Licensed Rights, including
+          technical modifications necessary to circumvent Effective
+          Technological Measures. For purposes of this Public License,
+          simply making modifications authorized by this Section 2(a)
+          (4) never produces Adapted Material.
+
+       5. Downstream recipients.
+
+            a. Offer from the Licensor -- Licensed Material. Every
+               recipient of the Licensed Material automatically
+               receives an offer from the Licensor to exercise the
+               Licensed Rights under the terms and conditions of this
+               Public License.
+
+            b. Additional offer from the Licensor -- Adapted Material.
+               Every recipient of Adapted Material from You
+               automatically receives an offer from the Licensor to
+               exercise the Licensed Rights in the Adapted Material
+               under the conditions of the Adapter's License You apply.
+
+            c. No downstream restrictions. You may not offer or impose
+               any additional or different terms or conditions on, or
+               apply any Effective Technological Measures to, the
+               Licensed Material if doing so restricts exercise of the
+               Licensed Rights by any recipient of the Licensed
+               Material.
+
+       6. No endorsement. Nothing in this Public License constitutes or
+          may be construed as permission to assert or imply that You
+          are, or that Your use of the Licensed Material is, connected
+          with, or sponsored, endorsed, or granted official status by,
+          the Licensor or others designated to receive attribution as
+          provided in Section 3(a)(1)(A)(i).
+
+  b. Other rights.
+
+       1. Moral rights, such as the right of integrity, are not
+          licensed under this Public License, nor are publicity,
+          privacy, and/or other similar personality rights; however, to
+          the extent possible, the Licensor waives and/or agrees not to
+          assert any such rights held by the Licensor to the limited
+          extent necessary to allow You to exercise the Licensed
+          Rights, but not otherwise.
+
+       2. Patent and trademark rights are not licensed under this
+          Public License.
+
+       3. To the extent possible, the Licensor waives any right to
+          collect royalties from You for the exercise of the Licensed
+          Rights, whether directly or through a collecting society
+          under any voluntary or waivable statutory or compulsory
+          licensing scheme. In all other cases the Licensor expressly
+          reserves any right to collect such royalties, including when
+          the Licensed Material is used other than for NonCommercial purposes.
+
+
+Section 3 -- License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the
+following conditions.
+
+  a. Attribution.
+
+       1. If You Share the Licensed Material (including in modified
+          form), You must:
+
+            a. retain the following if it is supplied by the Licensor
+               with the Licensed Material:
+
+                 i. identification of the creator(s) of the Licensed
+                    Material and any others designated to receive
+                    attribution, in any reasonable manner requested by
+                    the Licensor (including by pseudonym if
+                    designated);
+
+                ii. a copyright notice;
+
+               iii. a notice that refers to this Public License;
+
+                iv. a notice that refers to the disclaimer of
+                    warranties;
+
+                 v. a URI or hyperlink to the Licensed Material to the
+                    extent reasonably practicable;
+
+            b. indicate if You modified the Licensed Material and
+               retain an indication of any previous modifications; and
+
+            c. indicate the Licensed Material is licensed under this
+               Public License, and include the text of, or the URI or
+               hyperlink to, this Public License.
+
+       2. You may satisfy the conditions in Section 3(a)(1) in any
+          reasonable manner based on the medium, means, and context in
+          which You Share the Licensed Material. For example, it may be
+          reasonable to satisfy the conditions by providing a URI or
+          hyperlink to a resource that includes the required
+          information.
+
+       3. If requested by the Licensor, You must remove any of the
+          information required by Section 3(a)(1)(A) to the extent
+          reasonably practicable.
+
+  b. ShareAlike.
+
+     In addition to the conditions in Section 3(a), if You Share
+     Adapted Material You produce, the following conditions also apply.
+
+       1. The Adapter's License You apply must be a Creative Commons
+          license with the same License Elements, this version or
+          later, or a BY-NC-SA Compatible License.
+
+       2. You must include the text of, or the URI or hyperlink to, the
+          Adapter's License You apply. You may satisfy this condition
+          in any reasonable manner based on the medium, means, and
+          context in which You Share Adapted Material.
+
+       3. You may not offer or impose any additional or different terms
+          or conditions on, or apply any Effective Technological
+          Measures to, Adapted Material that restrict exercise of the
+          rights granted under the Adapter's License You apply.
+
+Section 4 -- Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that
+apply to Your use of the Licensed Material:
+
+  a. for the avoidance of doubt, Section 2(a)(1) grants You the right
+     to extract, reuse, reproduce, and Share all or a substantial
+     portion of the contents of the database for NonCommercial purposes only;
+
+  b. if You include all or a substantial portion of the database
+     contents in a database in which You have Sui Generis Database
+     Rights, then the database in which You have Sui Generis Database
+     Rights (but not its individual contents) is Adapted Material,
+
+     including for purposes of Section 3(b); and
+  c. You must comply with the conditions in Section 3(a) if You Share
+     all or a substantial portion of the contents of the database.
+
+For the avoidance of doubt, this Section 4 supplements and does not
+replace Your obligations under this Public License where the Licensed
+Rights include other Copyright and Similar Rights.
+
+
+Section 5 -- Disclaimer of Warranties and Limitation of Liability.
+
+  a. UNLESS OTHERWISE SEPARATELY UNDERTAKEN BY THE LICENSOR, TO THE
+     EXTENT POSSIBLE, THE LICENSOR OFFERS THE LICENSED MATERIAL AS-IS
+     AND AS-AVAILABLE, AND MAKES NO REPRESENTATIONS OR WARRANTIES OF
+     ANY KIND CONCERNING THE LICENSED MATERIAL, WHETHER EXPRESS,
+     IMPLIED, STATUTORY, OR OTHER. THIS INCLUDES, WITHOUT LIMITATION,
+     WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR
+     PURPOSE, NON-INFRINGEMENT, ABSENCE OF LATENT OR OTHER DEFECTS,
+     ACCURACY, OR THE PRESENCE OR ABSENCE OF ERRORS, WHETHER OR NOT
+     KNOWN OR DISCOVERABLE. WHERE DISCLAIMERS OF WARRANTIES ARE NOT
+     ALLOWED IN FULL OR IN PART, THIS DISCLAIMER MAY NOT APPLY TO YOU.
+
+  b. TO THE EXTENT POSSIBLE, IN NO EVENT WILL THE LICENSOR BE LIABLE
+     TO YOU ON ANY LEGAL THEORY (INCLUDING, WITHOUT LIMITATION,
+     NEGLIGENCE) OR OTHERWISE FOR ANY DIRECT, SPECIAL, INDIRECT,
+     INCIDENTAL, CONSEQUENTIAL, PUNITIVE, EXEMPLARY, OR OTHER LOSSES,
+     COSTS, EXPENSES, OR DAMAGES ARISING OUT OF THIS PUBLIC LICENSE OR
+     USE OF THE LICENSED MATERIAL, EVEN IF THE LICENSOR HAS BEEN
+     ADVISED OF THE POSSIBILITY OF SUCH LOSSES, COSTS, EXPENSES, OR
+     DAMAGES. WHERE A LIMITATION OF LIABILITY IS NOT ALLOWED IN FULL OR
+     IN PART, THIS LIMITATION MAY NOT APPLY TO YOU.
+
+  c. The disclaimer of warranties and limitation of liability provided
+     above shall be interpreted in a manner that, to the extent
+     possible, most closely approximates an absolute disclaimer and
+     waiver of all liability.
+
+Section 6 -- Term and Termination.
+
+  a. This Public License applies for the term of the Copyright and
+     Similar Rights licensed here. However, if You fail to comply with
+     this Public License, then Your rights under this Public License
+     terminate automatically.
+
+  b. Where Your right to use the Licensed Material has terminated under
+     Section 6(a), it reinstates:
+
+       1. automatically as of the date the violation is cured, provided
+          it is cured within 30 days of Your discovery of the
+          violation; or
+
+       2. upon express reinstatement by the Licensor.
+
+     For the avoidance of doubt, this Section 6(b) does not affect any
+     right the Licensor may have to seek remedies for Your violations
+     of this Public License.
+
+  c. For the avoidance of doubt, the Licensor may also offer the
+     Licensed Material under separate terms or conditions or stop
+     distributing the Licensed Material at any time; however, doing so
+     will not terminate this Public License.
+
+  d. Sections 1, 5, 6, 7, and 8 survive termination of this Public
+     License.
+
+
+Section 7 -- Other Terms and Conditions.
+
+  a. The Licensor shall not be bound by any additional or different
+     terms or conditions communicated by You unless expressly agreed.
+
+  b. Any arrangements, understandings, or agreements regarding the
+     Licensed Material not stated herein are separate from and
+     independent of the terms and conditions of this Public License.
+
+
+Section 8 -- Interpretation.
+
+  a. For the avoidance of doubt, this Public License does not, and
+     shall not be interpreted to, reduce, limit, restrict, or impose
+     conditions on any use of the Licensed Material that could lawfully
+     be made without permission under this Public License.
+
+  b. To the extent possible, if any provision of this Public License is
+     deemed unenforceable, it shall be automatically reformed to the
+     minimum extent necessary to make it enforceable. If the provision
+     cannot be reformed, it shall be severed from this Public License
+     without affecting the enforceability of the remaining terms and
+     conditions.
+
+  c. No term or condition of this Public License will be waived and no
+     failure to comply consented to unless expressly agreed to by the
+     Licensor.
+
+  d. Nothing in this Public License constitutes or may be interpreted
+     as a limitation upon, or waiver of, any privileges and immunities
+     that apply to the Licensor or You, including from the legal
+     processes of any jurisdiction or authority.
+
+=======================================================================
+
+Creative Commons is not a party to its public licenses.
+Notwithstanding, Creative Commons may elect to apply one of its public
+licenses to material it publishes and in those instances will be
+considered the “Licensor.” The text of the Creative Commons public
+licenses is dedicated to the public domain under the CC0 Public Domain
+Dedication. Except for the limited purpose of indicating that material
+is shared under a Creative Commons public license or as otherwise
+permitted by the Creative Commons policies published at
+creativecommons.org/policies, Creative Commons does not authorize the
+use of the trademark "Creative Commons" or any other trademark or logo
+of Creative Commons without its prior written consent including,
+without limitation, in connection with any unauthorized modifications
+to any of its public licenses or any other arrangements,
+understandings, or agreements concerning use of licensed material. For
+the avoidance of doubt, this paragraph does not form part of the public
+licenses.
+
+Creative Commons may be contacted at creativecommons.org.

--- a/git-repo-prep/licenses/by-sa-4.0.txt
+++ b/git-repo-prep/licenses/by-sa-4.0.txt
@@ -1,0 +1,428 @@
+Attribution-ShareAlike 4.0 International
+
+=======================================================================
+
+Creative Commons Corporation ("Creative Commons") is not a law firm and
+does not provide legal services or legal advice. Distribution of
+Creative Commons public licenses does not create a lawyer-client or
+other relationship. Creative Commons makes its licenses and related
+information available on an "as-is" basis. Creative Commons gives no
+warranties regarding its licenses, any material licensed under their
+terms and conditions, or any related information. Creative Commons
+disclaims all liability for damages resulting from their use to the
+fullest extent possible.
+
+Using Creative Commons Public Licenses
+
+Creative Commons public licenses provide a standard set of terms and
+conditions that creators and other rights holders may use to share
+original works of authorship and other material subject to copyright
+and certain other rights specified in the public license below. The
+following considerations are for informational purposes only, are not
+exhaustive, and do not form part of our licenses.
+
+     Considerations for licensors: Our public licenses are
+     intended for use by those authorized to give the public
+     permission to use material in ways otherwise restricted by
+     copyright and certain other rights. Our licenses are
+     irrevocable. Licensors should read and understand the terms
+     and conditions of the license they choose before applying it.
+     Licensors should also secure all rights necessary before
+     applying our licenses so that the public can reuse the
+     material as expected. Licensors should clearly mark any
+     material not subject to the license. This includes other CC-
+     licensed material, or material used under an exception or
+     limitation to copyright. More considerations for licensors:
+     wiki.creativecommons.org/Considerations_for_licensors
+
+     Considerations for the public: By using one of our public
+     licenses, a licensor grants the public permission to use the
+     licensed material under specified terms and conditions. If
+     the licensor's permission is not necessary for any reason--for
+     example, because of any applicable exception or limitation to
+     copyright--then that use is not regulated by the license. Our
+     licenses grant only permissions under copyright and certain
+     other rights that a licensor has authority to grant. Use of
+     the licensed material may still be restricted for other
+     reasons, including because others have copyright or other
+     rights in the material. A licensor may make special requests,
+     such as asking that all changes be marked or described.
+     Although not required by our licenses, you are encouraged to
+     respect those requests where reasonable. More considerations
+     for the public:
+     wiki.creativecommons.org/Considerations_for_licensees
+
+=======================================================================
+
+Creative Commons Attribution-ShareAlike 4.0 International Public
+License
+
+By exercising the Licensed Rights (defined below), You accept and agree
+to be bound by the terms and conditions of this Creative Commons
+Attribution-ShareAlike 4.0 International Public License ("Public
+License"). To the extent this Public License may be interpreted as a
+contract, You are granted the Licensed Rights in consideration of Your
+acceptance of these terms and conditions, and the Licensor grants You
+such rights in consideration of benefits the Licensor receives from
+making the Licensed Material available under these terms and
+conditions.
+
+Section 1 -- Definitions.
+
+  a. Adapted Material means material subject to Copyright and Similar
+     Rights that is derived from or based upon the Licensed Material
+     and in which the Licensed Material is translated, altered,
+     arranged, transformed, or otherwise modified in a manner requiring
+     permission under the Copyright and Similar Rights held by the
+     Licensor. For purposes of this Public License, where the Licensed
+     Material is a musical work, performance, or sound recording,
+     Adapted Material is always produced where the Licensed Material is
+     synched in timed relation with a moving image.
+
+  b. Adapter's License means the license You apply to Your Copyright
+     and Similar Rights in Your contributions to Adapted Material in
+     accordance with the terms and conditions of this Public License.
+
+  c. BY-SA Compatible License means a license listed at
+     creativecommons.org/compatiblelicenses, approved by Creative
+     Commons as essentially the equivalent of this Public License.
+
+  d. Copyright and Similar Rights means copyright and/or similar rights
+     closely related to copyright including, without limitation,
+     performance, broadcast, sound recording, and Sui Generis Database
+     Rights, without regard to how the rights are labeled or
+     categorized. For purposes of this Public License, the rights
+     specified in Section 2(b)(1)-(2) are not Copyright and Similar
+     Rights.
+
+  e. Effective Technological Measures means those measures that, in the
+     absence of proper authority, may not be circumvented under laws
+     fulfilling obligations under Article 11 of the WIPO Copyright
+     Treaty adopted on December 20, 1996, and/or similar international
+     agreements.
+
+  f. Exceptions and Limitations means fair use, fair dealing, and/or
+     any other exception or limitation to Copyright and Similar Rights
+     that applies to Your use of the Licensed Material.
+
+  g. License Elements means the license attributes listed in the name
+     of a Creative Commons Public License. The License Elements of this
+     Public License are Attribution and ShareAlike.
+
+  h. Licensed Material means the artistic or literary work, database,
+     or other material to which the Licensor applied this Public
+     License.
+
+  i. Licensed Rights means the rights granted to You subject to the
+     terms and conditions of this Public License, which are limited to
+     all Copyright and Similar Rights that apply to Your use of the
+     Licensed Material and that the Licensor has authority to license.
+
+  j. Licensor means the individual(s) or entity(ies) granting rights
+     under this Public License.
+
+  k. Share means to provide material to the public by any means or
+     process that requires permission under the Licensed Rights, such
+     as reproduction, public display, public performance, distribution,
+     dissemination, communication, or importation, and to make material
+     available to the public including in ways that members of the
+     public may access the material from a place and at a time
+     individually chosen by them.
+
+  l. Sui Generis Database Rights means rights other than copyright
+     resulting from Directive 96/9/EC of the European Parliament and of
+     the Council of 11 March 1996 on the legal protection of databases,
+     as amended and/or succeeded, as well as other essentially
+     equivalent rights anywhere in the world.
+
+  m. You means the individual or entity exercising the Licensed Rights
+     under this Public License. Your has a corresponding meaning.
+
+
+Section 2 -- Scope.
+
+  a. License grant.
+
+       1. Subject to the terms and conditions of this Public License,
+          the Licensor hereby grants You a worldwide, royalty-free,
+          non-sublicensable, non-exclusive, irrevocable license to
+          exercise the Licensed Rights in the Licensed Material to:
+
+            a. reproduce and Share the Licensed Material, in whole or
+               in part; and
+
+            b. produce, reproduce, and Share Adapted Material.
+
+       2. Exceptions and Limitations. For the avoidance of doubt, where
+          Exceptions and Limitations apply to Your use, this Public
+          License does not apply, and You do not need to comply with
+          its terms and conditions.
+
+       3. Term. The term of this Public License is specified in Section
+          6(a).
+
+       4. Media and formats; technical modifications allowed. The
+          Licensor authorizes You to exercise the Licensed Rights in
+          all media and formats whether now known or hereafter created,
+          and to make technical modifications necessary to do so. The
+          Licensor waives and/or agrees not to assert any right or
+          authority to forbid You from making technical modifications
+          necessary to exercise the Licensed Rights, including
+          technical modifications necessary to circumvent Effective
+          Technological Measures. For purposes of this Public License,
+          simply making modifications authorized by this Section 2(a)
+          (4) never produces Adapted Material.
+
+       5. Downstream recipients.
+
+            a. Offer from the Licensor -- Licensed Material. Every
+               recipient of the Licensed Material automatically
+               receives an offer from the Licensor to exercise the
+               Licensed Rights under the terms and conditions of this
+               Public License.
+
+            b. Additional offer from the Licensor -- Adapted Material.
+               Every recipient of Adapted Material from You
+               automatically receives an offer from the Licensor to
+               exercise the Licensed Rights in the Adapted Material
+               under the conditions of the Adapter's License You apply.
+
+            c. No downstream restrictions. You may not offer or impose
+               any additional or different terms or conditions on, or
+               apply any Effective Technological Measures to, the
+               Licensed Material if doing so restricts exercise of the
+               Licensed Rights by any recipient of the Licensed
+               Material.
+
+       6. No endorsement. Nothing in this Public License constitutes or
+          may be construed as permission to assert or imply that You
+          are, or that Your use of the Licensed Material is, connected
+          with, or sponsored, endorsed, or granted official status by,
+          the Licensor or others designated to receive attribution as
+          provided in Section 3(a)(1)(A)(i).
+
+  b. Other rights.
+
+       1. Moral rights, such as the right of integrity, are not
+          licensed under this Public License, nor are publicity,
+          privacy, and/or other similar personality rights; however, to
+          the extent possible, the Licensor waives and/or agrees not to
+          assert any such rights held by the Licensor to the limited
+          extent necessary to allow You to exercise the Licensed
+          Rights, but not otherwise.
+
+       2. Patent and trademark rights are not licensed under this
+          Public License.
+
+       3. To the extent possible, the Licensor waives any right to
+          collect royalties from You for the exercise of the Licensed
+          Rights, whether directly or through a collecting society
+          under any voluntary or waivable statutory or compulsory
+          licensing scheme. In all other cases the Licensor expressly
+          reserves any right to collect such royalties.
+
+
+Section 3 -- License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the
+following conditions.
+
+  a. Attribution.
+
+       1. If You Share the Licensed Material (including in modified
+          form), You must:
+
+            a. retain the following if it is supplied by the Licensor
+               with the Licensed Material:
+
+                 i. identification of the creator(s) of the Licensed
+                    Material and any others designated to receive
+                    attribution, in any reasonable manner requested by
+                    the Licensor (including by pseudonym if
+                    designated);
+
+                ii. a copyright notice;
+
+               iii. a notice that refers to this Public License;
+
+                iv. a notice that refers to the disclaimer of
+                    warranties;
+
+                 v. a URI or hyperlink to the Licensed Material to the
+                    extent reasonably practicable;
+
+            b. indicate if You modified the Licensed Material and
+               retain an indication of any previous modifications; and
+
+            c. indicate the Licensed Material is licensed under this
+               Public License, and include the text of, or the URI or
+               hyperlink to, this Public License.
+
+       2. You may satisfy the conditions in Section 3(a)(1) in any
+          reasonable manner based on the medium, means, and context in
+          which You Share the Licensed Material. For example, it may be
+          reasonable to satisfy the conditions by providing a URI or
+          hyperlink to a resource that includes the required
+          information.
+
+       3. If requested by the Licensor, You must remove any of the
+          information required by Section 3(a)(1)(A) to the extent
+          reasonably practicable.
+
+  b. ShareAlike.
+
+     In addition to the conditions in Section 3(a), if You Share
+     Adapted Material You produce, the following conditions also apply.
+
+       1. The Adapter's License You apply must be a Creative Commons
+          license with the same License Elements, this version or
+          later, or a BY-SA Compatible License.
+
+       2. You must include the text of, or the URI or hyperlink to, the
+          Adapter's License You apply. You may satisfy this condition
+          in any reasonable manner based on the medium, means, and
+          context in which You Share Adapted Material.
+
+       3. You may not offer or impose any additional or different terms
+          or conditions on, or apply any Effective Technological
+          Measures to, Adapted Material that restrict exercise of the
+          rights granted under the Adapter's License You apply.
+
+
+Section 4 -- Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that
+apply to Your use of the Licensed Material:
+
+  a. for the avoidance of doubt, Section 2(a)(1) grants You the right
+     to extract, reuse, reproduce, and Share all or a substantial
+     portion of the contents of the database;
+
+  b. if You include all or a substantial portion of the database
+     contents in a database in which You have Sui Generis Database
+     Rights, then the database in which You have Sui Generis Database
+     Rights (but not its individual contents) is Adapted Material,
+
+     including for purposes of Section 3(b); and
+  c. You must comply with the conditions in Section 3(a) if You Share
+     all or a substantial portion of the contents of the database.
+
+For the avoidance of doubt, this Section 4 supplements and does not
+replace Your obligations under this Public License where the Licensed
+Rights include other Copyright and Similar Rights.
+
+
+Section 5 -- Disclaimer of Warranties and Limitation of Liability.
+
+  a. UNLESS OTHERWISE SEPARATELY UNDERTAKEN BY THE LICENSOR, TO THE
+     EXTENT POSSIBLE, THE LICENSOR OFFERS THE LICENSED MATERIAL AS-IS
+     AND AS-AVAILABLE, AND MAKES NO REPRESENTATIONS OR WARRANTIES OF
+     ANY KIND CONCERNING THE LICENSED MATERIAL, WHETHER EXPRESS,
+     IMPLIED, STATUTORY, OR OTHER. THIS INCLUDES, WITHOUT LIMITATION,
+     WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR
+     PURPOSE, NON-INFRINGEMENT, ABSENCE OF LATENT OR OTHER DEFECTS,
+     ACCURACY, OR THE PRESENCE OR ABSENCE OF ERRORS, WHETHER OR NOT
+     KNOWN OR DISCOVERABLE. WHERE DISCLAIMERS OF WARRANTIES ARE NOT
+     ALLOWED IN FULL OR IN PART, THIS DISCLAIMER MAY NOT APPLY TO YOU.
+
+  b. TO THE EXTENT POSSIBLE, IN NO EVENT WILL THE LICENSOR BE LIABLE
+     TO YOU ON ANY LEGAL THEORY (INCLUDING, WITHOUT LIMITATION,
+     NEGLIGENCE) OR OTHERWISE FOR ANY DIRECT, SPECIAL, INDIRECT,
+     INCIDENTAL, CONSEQUENTIAL, PUNITIVE, EXEMPLARY, OR OTHER LOSSES,
+     COSTS, EXPENSES, OR DAMAGES ARISING OUT OF THIS PUBLIC LICENSE OR
+     USE OF THE LICENSED MATERIAL, EVEN IF THE LICENSOR HAS BEEN
+     ADVISED OF THE POSSIBILITY OF SUCH LOSSES, COSTS, EXPENSES, OR
+     DAMAGES. WHERE A LIMITATION OF LIABILITY IS NOT ALLOWED IN FULL OR
+     IN PART, THIS LIMITATION MAY NOT APPLY TO YOU.
+
+  c. The disclaimer of warranties and limitation of liability provided
+     above shall be interpreted in a manner that, to the extent
+     possible, most closely approximates an absolute disclaimer and
+     waiver of all liability.
+
+
+Section 6 -- Term and Termination.
+
+  a. This Public License applies for the term of the Copyright and
+     Similar Rights licensed here. However, if You fail to comply with
+     this Public License, then Your rights under this Public License
+     terminate automatically.
+
+  b. Where Your right to use the Licensed Material has terminated under
+     Section 6(a), it reinstates:
+
+       1. automatically as of the date the violation is cured, provided
+          it is cured within 30 days of Your discovery of the
+          violation; or
+
+       2. upon express reinstatement by the Licensor.
+
+     For the avoidance of doubt, this Section 6(b) does not affect any
+     right the Licensor may have to seek remedies for Your violations
+     of this Public License.
+
+  c. For the avoidance of doubt, the Licensor may also offer the
+     Licensed Material under separate terms or conditions or stop
+     distributing the Licensed Material at any time; however, doing so
+     will not terminate this Public License.
+
+  d. Sections 1, 5, 6, 7, and 8 survive termination of this Public
+     License.
+
+
+Section 7 -- Other Terms and Conditions.
+
+  a. The Licensor shall not be bound by any additional or different
+     terms or conditions communicated by You unless expressly agreed.
+
+  b. Any arrangements, understandings, or agreements regarding the
+     Licensed Material not stated herein are separate from and
+     independent of the terms and conditions of this Public License.
+
+
+Section 8 -- Interpretation.
+
+  a. For the avoidance of doubt, this Public License does not, and
+     shall not be interpreted to, reduce, limit, restrict, or impose
+     conditions on any use of the Licensed Material that could lawfully
+     be made without permission under this Public License.
+
+  b. To the extent possible, if any provision of this Public License is
+     deemed unenforceable, it shall be automatically reformed to the
+     minimum extent necessary to make it enforceable. If the provision
+     cannot be reformed, it shall be severed from this Public License
+     without affecting the enforceability of the remaining terms and
+     conditions.
+
+  c. No term or condition of this Public License will be waived and no
+     failure to comply consented to unless expressly agreed to by the
+     Licensor.
+
+  d. Nothing in this Public License constitutes or may be interpreted
+     as a limitation upon, or waiver of, any privileges and immunities
+     that apply to the Licensor or You, including from the legal
+     processes of any jurisdiction or authority.
+
+
+=======================================================================
+
+Creative Commons is not a party to its public licenses.
+Notwithstanding, Creative Commons may elect to apply one of its public
+licenses to material it publishes and in those instances will be
+considered the “Licensor.” The text of the Creative Commons public
+licenses is dedicated to the public domain under the CC0 Public Domain
+Dedication. Except for the limited purpose of indicating that material
+is shared under a Creative Commons public license or as otherwise
+permitted by the Creative Commons policies published at
+creativecommons.org/policies, Creative Commons does not authorize the
+use of the trademark "Creative Commons" or any other trademark or logo
+of Creative Commons without its prior written consent including,
+without limitation, in connection with any unauthorized modifications
+to any of its public licenses or any other arrangements,
+understandings, or agreements concerning use of licensed material. For
+the avoidance of doubt, this paragraph does not form part of the public
+licenses.
+
+Creative Commons may be contacted at creativecommons.org.
+
+https://choosealicense.com/licenses/cc-by-sa-4.0/

--- a/git-repo-prep/main.py
+++ b/git-repo-prep/main.py
@@ -318,6 +318,8 @@ def init():
     # This was not needed after all
     # install_gh_cli()
     GitRepo.configure_secrets()
+    sspawn('git config --global user.email "staxly@openstax.org"')
+    sspawn('git config --global user.name "Staxly"')
 
 
 def main():

--- a/git-repo-prep/main.py
+++ b/git-repo-prep/main.py
@@ -1,0 +1,310 @@
+import json
+import logging
+import os
+import re
+import shutil
+from pathlib import Path
+from shlex import split
+from subprocess import PIPE, run
+from typing import Any, Dict, List, Optional
+
+REPO_PREP_SCRIPT = Path(__file__).parent/'index.ts'
+
+
+class GHResponse:
+    def __init__(self, response: bytes):
+        self.response = response
+
+    @property
+    def text(self):
+        return self.response.decode('utf-8').strip()
+
+    @property
+    def json(self):
+        return json.loads(self.response)
+
+
+def clone_repo(remote_repo: str, path: str):
+    gh(f'repo clone "{remote_repo}" "{path}"')
+
+
+class GitRepo:
+    def __init__(self, path: str = ".", working_branch: str = 'main',
+                 remote_repo: Optional[str] = None, create: bool = False):
+        self.path = path
+        self.working_branch = working_branch
+        self.remote_repo = remote_repo
+        self._init(create)
+
+    def __call__(self, command: str) -> str:
+        return sspawn(
+            f'git -C "{self.path}" {command}').decode('utf-8').strip()
+
+    @property
+    def branch(self) -> str:
+        return self('branch --show-current')
+
+    @property
+    def branches_local(self) -> List[str]:
+        return [br.lstrip('*').strip() for br in self('branch -l').split('\n')]
+
+    @property
+    def branches_remote(self) -> List[str]:
+        return [bs.strip() for bs in self('branch -rl').split('\n')]
+
+    @property
+    def tags(self) -> List[str]:
+        return [tag.strip() for tag in self('tag -l').split('\n')]
+
+    @property
+    def has_changes(self) -> bool:
+        return self('status -s') != ''
+
+    def checkout(self, branch: str, create: bool = False):
+        if create:
+            self(f'checkout -b "{branch}"')
+        else:
+            self(f'checkout "{branch}"')
+        self.working_branch = branch
+
+    def commit_all(self, msg: str):
+        if self.has_changes:
+            self('add .')
+            self(f'commit -m "{msg}"')
+
+    def push_changes(self):
+        if self(f'diff origin "{self.working_branch}"') != '':
+            self(f'push origin "{self.working_branch}"')
+
+    def clone_repo(self):
+        parent_path = Path(self.path).parent
+        parent_path.mkdir(parents=True, exist_ok=True)
+        git_url = f'https://github.com/{self.remote_repo}.git'
+        sspawn(f'git -C {parent_path} clone {git_url}')
+
+    @staticmethod
+    def configure_secrets():
+        github_token = os.environ.get('GITHUB_TOKEN', None)
+        if github_token is None:
+            logging.warning('No GitHub creds, cannot access private repos')
+            return
+        creds_dir = Path.cwd()/'tmp-gh-creds'
+        creds_file = creds_dir/'gh-creds'
+        creds_dir.mkdir(parents=True, exist_ok=True)
+        sspawn('git config --global credential.helper'
+               f' "store --file={creds_file}"')
+        creds_file.write_text(
+            f'https://{github_token}:x-oauth-basic@github.com')
+
+    def _init(self, create: bool = False):
+        branch = None
+        try:
+            branch = self.branch
+        except Exception:
+            if self.remote_repo is not None:
+                self.clone_repo()
+            elif not create:
+                raise
+            else:
+                self('init')
+            branch = self.branch
+        if branch != self.working_branch:
+            branch = self.working_branch
+            if self.has_changes:
+                self('stash')
+            if branch not in self.branches_local:
+                self.checkout(branch, True)
+            else:
+                self.checkout(branch, False)
+        if self.remote_repo is not None:
+            self(f'pull origin "{branch}"')
+
+
+def spawn(command: List[str]) -> bytes:
+    logging.info(' '.join(command))
+    p = run(command, stdout=PIPE, stderr=PIPE)
+    if p.returncode != 0:
+        if p.stderr:
+            err = f'{command}: {p.stderr.decode("utf-8")}'
+        else:
+            err = f'ERROR: could not run {command}'
+        raise Exception(err)
+    return p.stdout
+
+
+def sspawn(command: str) -> bytes:
+    return spawn(split(command))
+
+
+def gh(command: str) -> GHResponse:
+    return GHResponse(spawn(['gh'] + split(command)))
+
+
+def get_books_list() -> List[str]:
+    cache = Path(__file__).parent/'books-list.json'
+    if cache.exists():
+        return json.loads(cache.read_bytes())
+    response = gh('repo list openstax --private')
+    books_list = [
+        line.split('\t')[0]
+        for line in response.text.split('\n')
+        if 'osbooks-' in line]
+    cache.write_text(json.dumps(books_list))
+    return books_list
+
+
+def get_approved_books() -> List[str]:
+    abl_path = Path('approved-book-list.json')
+    if not abl_path.exists():
+        sspawn(f'wget {os.environ["ABL_URL"]}')
+    abl = json.loads(abl_path.read_bytes())
+    return [
+        book['repository_name']
+        for book in abl['approved_books']
+    ]
+
+
+def get_branches_to_delete(git: GitRepo):
+    remote_branches = [
+        bs.strip()
+        for bs in git.branches_remote
+        # filter out HEAD branch and 1e, 2e, etc.
+        if 'HEAD' not in bs and re.match(r'\s*origin/[0-9]+e', bs) is None]
+    # remove instead of filter: this ensures it exists
+    remote_branches.remove('origin/main')
+    return remote_branches
+
+
+def cleanup_branches(git: GitRepo):
+    for branch_spec in get_branches_to_delete(git):
+        remote, branch = branch_spec.split('/')
+        git(f'push "{remote}" --delete "{branch}"')
+
+
+def get_tags_to_delete(git: GitRepo):
+    return [tag for tag in git.tags
+            if re.match(r'[0-9]+(rc){0,1}', tag) is not None]
+
+
+def cleanup_tags(git: GitRepo):
+    for tag in get_tags_to_delete(git):
+        git(f'push origin --delete "{tag}"')
+
+
+def remove_files(file_paths: List[Path]):
+    for file_path in file_paths:
+        if file_path.exists():
+            logging.info(f'Removing {file_path}')
+            file_path.unlink()
+
+
+def cleanup_files(git: GitRepo, book_path: Path):
+    remove_files([book_path/'canonical.json'] +
+                 list(book_path.glob('editor-*.vsix')))
+    git.commit_all('Remove unwanted files')
+
+
+def ensure_correct_license(
+    git: GitRepo,
+    book_path: Path,
+    book_meta: Dict[str, Any]
+):
+    license_dir = Path('licenses')
+    slugs_meta = book_meta['slugsMeta']
+    license_info = slugs_meta[0]['colMeta']['license']
+    for slug_meta in slugs_meta[1:]:
+        col_meta = slug_meta['colMeta']
+        col_license_info = col_meta['license']
+        if license_info != col_license_info:
+            raise Exception('Licenses differ between collections')
+    license_type = license_info['type']
+    license_version = license_info['version']
+    license_file = license_dir/f'{license_type}-{license_version}.txt'
+    if not license_file.exists():
+        logging.warning(f'Unknown license: {license_file}')
+        return
+    shutil.copy(license_file, book_path/'LICENSE')
+    git.commit_all('Update LICENSE')
+
+
+def run_repo_prep(git: GitRepo, book_path: Path):
+    book_meta = json.loads(sspawn(f'ts-node {REPO_PREP_SCRIPT} {book_path}'))
+    git.commit_all('Add README and repo settings')
+    return book_meta
+
+
+def update_path(new_segment: str):
+    path = os.environ.get('PATH', None)
+    if path is not None:
+        os.environ['PATH'] = f'{new_segment}:{path}'
+    else:
+        os.environ['PATH'] = f'{new_segment}'
+
+
+def install_gh_cli():
+    ver = os.environ.get('GH_CLI_VERSION', '2.9.0')
+    cli_root = f'gh_{ver}_linux_amd64'
+    tar_file = f'gh_{ver}_linux_amd64.tar.gz'
+    if not cli_bin.exists():
+        tar_file_path = Path(tar_file)
+        if not tar_file_path.exists():
+            sspawn('wget https://github.com/cli/cli/releases/download/'
+                   f'v{ver}/{tar_file}')
+        sspawn(f'tar -xf {tar_file}')
+        tar_file_path.unlink()
+    update_path(Path(cli_root)/'bin')
+
+
+def install_node_modules():
+    node_modules = REPO_PREP_SCRIPT.parent/'node_modules'
+    if not node_modules.exists():
+        sspawn(f'npm install "{REPO_PREP_SCRIPT.parent}"')
+    update_path(node_modules/'.bin')
+
+
+def list_prs():
+    # Example return value:
+    # number  title                                           status
+    # 1       add style to META-INF/books.xml meta-inf-style  OPEN
+    for book in get_approved_books():
+        repo = f'openstax/{book}'
+        print(sspawn(f'gh pr list -R {repo}').decode('utf-8'))
+
+
+def init():
+    logging.getLogger().setLevel(logging.INFO)
+    env = Path(__file__).parent/'.env'
+    if env.exists():
+        for line in env.read_text().split('\n'):
+            k, v = [s.strip() for s in line.split('=')]
+            os.environ[k] = v
+    install_node_modules()
+    # This was not needed after all
+    # install_gh_cli()
+    GitRepo.configure_secrets()
+
+
+def main():
+    for book in get_approved_books():
+        repo = f'openstax/{book}'
+        book_path = Path(book)
+        logging.info(f'\x1b[33m========> {repo} <========\x1b[37m')
+        try:
+            git = GitRepo(str(book_path), remote_repo=repo)
+            print(f'Would remove {get_branches_to_delete(git)}')
+            print(f'Would remove {get_tags_to_delete(git)}')
+            cleanup_files(git, book_path)
+            book_meta = run_repo_prep(git, book_path)
+            ensure_correct_license(git, book_path, book_meta)
+            # NOTE: These steps are commented out during testing because they
+            #       all push changes to the Github repositories
+            # cleanup_branches(git)
+            # cleanup_tags(git)
+            # git.push_changes()
+        except Exception as e:
+            logging.error(f'\x1b[31m{repo}: {e}\x1b[37m')
+
+
+if __name__ == '__main__':
+    init()
+    main()

--- a/git-repo-prep/package-lock.json
+++ b/git-repo-prep/package-lock.json
@@ -1,0 +1,313 @@
+{
+  "name": "xml",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "xml",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@types/node": "^17.0.23",
+        "@types/xmldom": "^0.1.31",
+        "ts-node": "^10.7.0",
+        "xmldom": "^0.6.0",
+        "xpath-ts": "^1.3.13"
+      }
+    },
+    "node_modules/@cspotcode/source-map-consumer": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
+      "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
+      "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
+      "dependencies": {
+        "@cspotcode/source-map-consumer": "0.8.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
+      "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg=="
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
+      "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw=="
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
+      "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg=="
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
+      "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA=="
+    },
+    "node_modules/@types/node": {
+      "version": "17.0.23",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
+      "integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw=="
+    },
+    "node_modules/@types/xmldom": {
+      "version": "0.1.31",
+      "resolved": "https://registry.npmjs.org/@types/xmldom/-/xmldom-0.1.31.tgz",
+      "integrity": "sha512-bVy7s0nvaR5D1mT1a8ZkByHWNOGb6Vn4yi5TWhEdmyKlAG+08SA7Md6+jH+tYmMLueAwNeWvHHpeKrr6S4c4BA=="
+    },
+    "node_modules/acorn": {
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
+      "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
+    },
+    "node_modules/ts-node": {
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.7.0.tgz",
+      "integrity": "sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.7.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.0",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
+      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg=="
+    },
+    "node_modules/xmldom": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.6.0.tgz",
+      "integrity": "sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/xpath-ts": {
+      "version": "1.3.13",
+      "resolved": "https://registry.npmjs.org/xpath-ts/-/xpath-ts-1.3.13.tgz",
+      "integrity": "sha512-eNVXzDWbCV9KEB6fGNQ3qHFGC9PWBH7y2h13vZ+CMPNqOTZ+fgYTG4Sb0p5bVHiAwZrzgE6/tx987003P3dYpA=="
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "engines": {
+        "node": ">=6"
+      }
+    }
+  },
+  "dependencies": {
+    "@cspotcode/source-map-consumer": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
+      "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg=="
+    },
+    "@cspotcode/source-map-support": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
+      "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
+      "requires": {
+        "@cspotcode/source-map-consumer": "0.8.0"
+      }
+    },
+    "@tsconfig/node10": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
+      "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg=="
+    },
+    "@tsconfig/node12": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
+      "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw=="
+    },
+    "@tsconfig/node14": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
+      "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg=="
+    },
+    "@tsconfig/node16": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
+      "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA=="
+    },
+    "@types/node": {
+      "version": "17.0.23",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
+      "integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw=="
+    },
+    "@types/xmldom": {
+      "version": "0.1.31",
+      "resolved": "https://registry.npmjs.org/@types/xmldom/-/xmldom-0.1.31.tgz",
+      "integrity": "sha512-bVy7s0nvaR5D1mT1a8ZkByHWNOGb6Vn4yi5TWhEdmyKlAG+08SA7Md6+jH+tYmMLueAwNeWvHHpeKrr6S4c4BA=="
+    },
+    "acorn": {
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
+      "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A=="
+    },
+    "acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA=="
+    },
+    "arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
+    },
+    "create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
+    },
+    "diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
+    },
+    "make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
+    },
+    "ts-node": {
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.7.0.tgz",
+      "integrity": "sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==",
+      "requires": {
+        "@cspotcode/source-map-support": "0.7.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.0",
+        "yn": "3.1.1"
+      }
+    },
+    "typescript": {
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
+      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
+      "peer": true
+    },
+    "v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg=="
+    },
+    "xmldom": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.6.0.tgz",
+      "integrity": "sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg=="
+    },
+    "xpath-ts": {
+      "version": "1.3.13",
+      "resolved": "https://registry.npmjs.org/xpath-ts/-/xpath-ts-1.3.13.tgz",
+      "integrity": "sha512-eNVXzDWbCV9KEB6fGNQ3qHFGC9PWBH7y2h13vZ+CMPNqOTZ+fgYTG4Sb0p5bVHiAwZrzgE6/tx987003P3dYpA=="
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="
+    }
+  }
+}

--- a/git-repo-prep/package.json
+++ b/git-repo-prep/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "xml",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "gen": "ts-node index.ts"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@types/node": "^17.0.23",
+    "@types/xmldom": "^0.1.31",
+    "ts-node": "^10.7.0",
+    "xmldom": "^0.6.0",
+    "xpath-ts": "^1.3.13"
+  }
+}

--- a/git-repo-prep/static/book.md
+++ b/git-repo-prep/static/book.md
@@ -1,11 +1,13 @@
-# {book_title}
+# {{ book_title }}
 
-_{book_title}_ is a textbook published by [OpenStax](https://openstax.org/), a non profit organization that is part of [Rice University](https://www.rice.edu/).
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
 
-The book can be viewed [online](https://openstax.org/details/books/{book_slug}), where you can also see a list of contributors.
+_{{ book_title }}_ is a textbook published by [OpenStax](https://openstax.org/), a non profit organization that is part of [Rice University](https://www.rice.edu/).
+
+The book can be viewed [online]({{ book_link }}), where you can also see a list of contributors.
 
 ## License
-This book is available under the [{license_text}](./LICENSE) license.
+This book is available under the [{{ license_text }}](./LICENSE) license.
 
 ## Support
 If you would like to support the creation of free textbooks for students, your [donations are welcome](https://riceconnect.rice.edu/donation/support-openstax-banner).

--- a/git-repo-prep/static/book.md
+++ b/git-repo-prep/static/book.md
@@ -1,0 +1,11 @@
+# {book_title}
+
+_{book_title}_ is a textbook published by [OpenStax](https://openstax.org/), a non profit organization that is part of [Rice University](https://www.rice.edu/).
+
+The book can be viewed [online](https://openstax.org/details/books/{book_slug}), where you can also see a list of contributors.
+
+## License
+This book is available under the [{license_text}](./LICENSE) license.
+
+## Support
+If you would like to support the creation of free textbooks for students, your [donations are welcome](https://riceconnect.rice.edu/donation/support-openstax-banner).

--- a/git-repo-prep/static/bundle.md
+++ b/git-repo-prep/static/bundle.md
@@ -1,0 +1,12 @@
+# {book_titles}
+
+_{book_titles}_ are textbooks published by [OpenStax](https://openstax.org/), a non profit organization that is part of [Rice University](https://www.rice.edu/).
+
+To view these books online and view contributors, please visit:
+{book_links}
+
+## License
+These books are available under the [{license_text}](./LICENSE) license.
+
+## Support
+If you would like to support the creation of free textbooks for students, your [donations are welcome](https://riceconnect.rice.edu/donation/support-openstax-banner).

--- a/git-repo-prep/static/bundle.md
+++ b/git-repo-prep/static/bundle.md
@@ -1,12 +1,14 @@
-# {book_titles}
+# {{ book_titles }}
 
-_{book_titles}_ are textbooks published by [OpenStax](https://openstax.org/), a non profit organization that is part of [Rice University](https://www.rice.edu/).
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
+
+_{{ book_titles }}_ are textbooks published by [OpenStax](https://openstax.org/), a non profit organization that is part of [Rice University](https://www.rice.edu/).
 
 To view these books online and view contributors, please visit:
-{book_links}
+{{ book_links }}
 
 ## License
-These books are available under the [{license_text}](./LICENSE) license.
+These books are available under the [{{ license_text }}](./LICENSE) license.
 
 ## Support
 If you would like to support the creation of free textbooks for students, your [donations are welcome](https://riceconnect.rice.edu/donation/support-openstax-banner).

--- a/git-repo-prep/static/repo-settings/.github/settings.yml
+++ b/git-repo-prep/static/repo-settings/.github/settings.yml
@@ -1,7 +1,6 @@
 # These settings are synced to GitHub by https://probot.github.io/apps/settings/
 
 repository:
-  # See https://docs.github.com/en/rest/reference/repos#update-a-repository for all available settings.
   private: false
 
   has_issues: false
@@ -9,16 +8,10 @@ repository:
   has_projects: false
   has_downloads: false
 
-  default_branch: main
-
   allow_auto_merge: true
   delete_branch_on_merge: true
-  allow_forking: true
 
-# See https://docs.github.com/en/rest/reference/teams#add-or-update-team-repository-permissions for available options
 teams:
-  - name: all
-    permission: pull
   - name: ce-admins
     permission: push
   - name: ce-all

--- a/git-repo-prep/static/repo-settings/.github/settings.yml
+++ b/git-repo-prep/static/repo-settings/.github/settings.yml
@@ -1,0 +1,45 @@
+# These settings are synced to GitHub by https://probot.github.io/apps/settings/
+
+repository:
+  # See https://docs.github.com/en/rest/reference/repos#update-a-repository for all available settings.
+  private: false
+
+  has_issues: false
+  has_wiki: false
+  has_projects: false
+  has_downloads: false
+
+  default_branch: main
+
+  allow_auto_merge: true
+  delete_branch_on_merge: true
+  allow_forking: true
+
+# Collaborators: give specific users access to this repository.
+# See https://docs.github.com/en/rest/reference/repos#add-a-repository-collaborator for available options
+collaborators:
+
+# See https://docs.github.com/en/rest/reference/teams#add-or-update-team-repository-permissions for available options
+teams:
+  - name: all
+    permission: pull
+  - name: ce-admins
+    permission: admin
+  - name: ce-all
+    permission: triage
+  - name: content-managers
+    permission: admin
+
+branches:
+  - name: main
+    # https://docs.github.com/en/rest/reference/repos#update-branch-protection
+    # Branch Protection settings. Set to null to disable
+    protection:
+      # Required. Require at least one approving review on a pull request, before merging. Set to null to disable.
+      required_pull_request_reviews: null
+      # Required. Require status checks to pass before merging. Set to null to disable
+      required_status_checks: null
+      # Required. Enforce all configured restrictions for administrators. Set to true to enforce required status checks for repository administrators. Set to null to disable.
+      enforce_admins: null
+      # Required. Restrict who can push to this branch. Team and user restrictions are only available for organization-owned repositories. Set to null to disable.
+      restrictions: null

--- a/git-repo-prep/static/repo-settings/.github/settings.yml
+++ b/git-repo-prep/static/repo-settings/.github/settings.yml
@@ -15,31 +15,13 @@ repository:
   delete_branch_on_merge: true
   allow_forking: true
 
-# Collaborators: give specific users access to this repository.
-# See https://docs.github.com/en/rest/reference/repos#add-a-repository-collaborator for available options
-collaborators:
-
 # See https://docs.github.com/en/rest/reference/teams#add-or-update-team-repository-permissions for available options
 teams:
   - name: all
     permission: pull
   - name: ce-admins
-    permission: admin
+    permission: push
   - name: ce-all
     permission: triage
   - name: content-managers
-    permission: admin
-
-branches:
-  - name: main
-    # https://docs.github.com/en/rest/reference/repos#update-branch-protection
-    # Branch Protection settings. Set to null to disable
-    protection:
-      # Required. Require at least one approving review on a pull request, before merging. Set to null to disable.
-      required_pull_request_reviews: null
-      # Required. Require status checks to pass before merging. Set to null to disable
-      required_status_checks: null
-      # Required. Enforce all configured restrictions for administrators. Set to true to enforce required status checks for repository administrators. Set to null to disable.
-      enforce_admins: null
-      # Required. Restrict who can push to this branch. Team and user restrictions are only available for organization-owned repositories. Set to null to disable.
-      restrictions: null
+    permission: push

--- a/git-repo-prep/static/repo-settings/.github/settings.yml
+++ b/git-repo-prep/static/repo-settings/.github/settings.yml
@@ -1,4 +1,4 @@
-# These settings are synced to GitHub by https://probot.github.io/apps/settings/
+# These settings are synced to GitHub by https://probot.github.io/apps/settings/ via https://github.com/openstax/staxly
 
 repository:
   private: false

--- a/git-repo-prep/static/repo-settings/.gitpod.yml
+++ b/git-repo-prep/static/repo-settings/.gitpod.yml
@@ -1,0 +1,3 @@
+vscode:
+  extensions:
+    - openstax.editor


### PR DESCRIPTION
The python script is he main entry point and will automatically install any additional dependencies. Note that it will install `ts-node` globally. I used python instead of bash because I prefer python's error handling. I stole most of the `GitRepo` class from a personal project and added support for remotes.

All of the python functions and classes that use the GitHub CLI (`gh`) are not used anymore. I kept them around because they might be useful again. For example, today I used `list_prs` to help me find all the books that had PRs. There was such a small number of PRs that I decided to manually close them. 

I used typescript for generating the README and copying the settings because we would like to have this functionality in POET eventually. Hopefully it will be fairly easy to migrate this script.